### PR TITLE
Update _index.md

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -369,8 +369,8 @@ Start with `kubectl`:
 ```shell
 # use tkn's --dry-run option to save the TaskRun to a file
 tkn task start echo --dry-run > taskRun.yaml
-# apply the TaskRun
-kubectl apply -f taskRun.yaml
+# create the TaskRun
+kubectl create -f taskRun.yaml
 ```
 
 Tekton will now start running your `Task`. To see the logs of the `TaskRun`, run 


### PR DESCRIPTION
# Changes

Changed from `apply` to `create` due to the declarative nature of `apply`. You can not use `generateName` with `apply`.
The error that happens is:

```
❯ kubectl apply -f taskRun.yml
error: error when retrieving current configuration of:
Resource: "tekton.dev/v1beta1, Resource=taskruns", GroupVersionKind: "tekton.dev/v1beta1, Kind=TaskRun"
Name: "", Namespace: "hello-world-pipeline"
from server for: "taskRun.yml": resource name may not be empty
```
The following is the correct behavior. 
```
❯ kubectl create -f taskRun.yml
taskrun.tekton.dev/echo-run-c5dtm created
```
Please look at:  https://github.com/kubernetes/kubernetes/issues/44501#issuecomment-294255660

Signed-off-by: JJ Asghar <jjasghar@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
